### PR TITLE
Fix license

### DIFF
--- a/HttpMocks.nuspec
+++ b/HttpMocks.nuspec
@@ -6,8 +6,8 @@
     <authors>Shalin Andrey</authors>
     <owners>Shalin Andrey</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <license type="expression">MIT</license>
     <description>Library for integration testing. https://github.com/shalin-andrey/HttpMocks</description>
+    <license type="expression">MIT</license>
     <tags>HttpMocks Kontur</tags>
   </metadata>
   <files>

--- a/HttpMocks.nuspec
+++ b/HttpMocks.nuspec
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<package>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>HttpMocks</id>
     <version>$version$</version>
     <authors>Shalin Andrey</authors>
     <owners>Shalin Andrey</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
     <description>Library for integration testing. https://github.com/shalin-andrey/HttpMocks</description>
     <tags>HttpMocks Kontur</tags>
   </metadata>


### PR DESCRIPTION
Using exact package scheme "http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd", otherwise it fails with 
```
The element 'metadata' in namespace 'http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' has invalid child element 'license' in namespace 'http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd'.
```