### PR TITLE
Correctly stop Mock on Linux

### DIFF
--- a/HttpMocks/Implementation/Core/HttpContext.cs
+++ b/HttpMocks/Implementation/Core/HttpContext.cs
@@ -15,7 +15,7 @@ namespace HttpMocks.Implementation.Core
 
         public static HttpContext CreateInvalid()
         {
-            return new HttpContext(null, false);
+            return new HttpContext(null, true);
         }
 
         private HttpContext(HttpListenerContext httpListenerContext, bool isInvalid)


### PR DESCRIPTION
Hello. This is fix for `HttpMocks.VerifyAll` on Linux fails with exception like

```
HttpMocks.Exceptions.AssertHttpMockException : Unhandled exception: System.NullReferenceException: Object reference not set to an instance of an objec...

HttpMocks.Exceptions.AssertHttpMockException : Unhandled exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at HttpMocks.Implementation.Core.HttpContext.ReadRequestAsync() in /projects/kontur/HttpMocks/HttpMocks/Implementation/Core/HttpContext.cs:line 31
   at HttpMocks.Implementation.StartedHttpMock.StartAsync() in /projects/kontur/HttpMocks/HttpMocks/Implementation/StartedHttpMock.cs:line 58

   at HttpMocks.HttpMockRepository.VerifyAll() in /projects/kontur/HttpMocks/HttpMocks/HttpMockRepository.cs:line 81
   at HttpMocks.Tests.Integrational.MethodAndPathTests.TestFailWhenAnyActualRepeatMoreThatExpected() in /projects/kontur/HttpMocks/HttpMocks.Tests/Integrational/MethodAndPathTests.cs:line 152
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
```

It happens because `HttpListenerWrapper` in case of exceptions creates invalid HttpContext, but method `HttpContext.CreateInvalid` passes `false` as `isInvalid` value. And `StartedHttpMock` after checking for `context.IsInvalid` tries to read request one more time from invalid context.

I think it work on Windows because implementation of HttpListener is different from Linux variant. Windows version [does some stuff](https://github.com/dotnet/runtime/blob/192513899ef03832ec7c3cc5ab38f79bfbe2360e/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs#L357) to gracefully stop Listener. And Linux ( or Managed ) version just [sets](https://github.com/dotnet/runtime/blob/192513899ef03832ec7c3cc5ab38f79bfbe2360e/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpListener.Managed.cs#L247C41-L247C64) Exception in Listener result.

If we set correct `IsInvalid` value - all works as expected. 

Test before fix, Windows:
![image](https://github.com/shalin-andrey/HttpMocks/assets/1222013/b913c370-b09f-4964-8a8e-9f6453f68589)
Test before fix, Linux:
![image](https://github.com/shalin-andrey/HttpMocks/assets/1222013/72b622ed-4931-4977-ac9e-1f6dd40cea52)

Test after fix, Windows:
![image](https://github.com/shalin-andrey/HttpMocks/assets/1222013/dc59a805-e1f8-4f11-b9a4-ff72b74881a9)
Test after fix, Linux:
![image](https://github.com/shalin-andrey/HttpMocks/assets/1222013/9c5dee49-abc3-4ba1-bc94-56902f93ead7)

